### PR TITLE
Don't specify the primary group when dropping privileges

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,6 @@ fn main() {
 
     PrivDrop::default()
         .user("nobody")
-        .group("nobody")
         .group_list(&groups)
         .apply()
         .unwrap_or_else(|e| { panic!("Failed to drop privileges: {}", e) });


### PR DESCRIPTION
The primary group of the "nobody" user can be named differently among distributions, for example on Debian it is named "nogroup" instead of "nobody", so don't specify it, in which case the correct group will be chosen automatically.