### PR TITLE
Add flake.nix for building with Nix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703068421,
+        "narHash": "sha256-WSw5Faqlw75McIflnl5v7qVD/B3S2sLh+968bpOGrWA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d65bceaee0fb1e64363f7871bc43dc1c6ecad99f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "The most basic dynamic function row daemon possible";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+  };
+  outputs = { self, nixpkgs }:
+    let
+      pkgs = import nixpkgs { system = "aarch64-linux"; };
+    in
+    rec {
+      packages.aarch64-linux.default = pkgs.rustPlatform.buildRustPackage {
+        name = "tiny-dfr";
+        version = "0.2.0";
+        src = ./.;
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+        };
+        nativeBuildInputs = [
+          pkgs.pkg-config
+        ];
+        buildInputs = [
+          pkgs.cairo
+          pkgs.libinput
+          pkgs.freetype
+          pkgs.fontconfig
+          pkgs.glib
+          pkgs.pango
+          pkgs.gdk-pixbuf
+          pkgs.libxml2
+        ];
+      };
+      devShells.aarch64-linux.default = pkgs.mkShell {
+        inputsFrom = [
+          packages.aarch64-linux.default
+        ];
+        packages = [
+	  pkgs.rustfmt
+          pkgs.rust-analyzer
+        ];
+        RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+      };
+    };
+}


### PR DESCRIPTION
Add flake.nix and flake.lock for building with the Nix package manager.
Flake contains tiny-dfr package in addition to a development shell that includes rust_analyzer and rustfmt, setting the appropriate environment variable for editors to find the source for std.