### PR TITLE
Fix bug caused by pressing/releasing the fn key while a button was held.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -433,6 +433,12 @@ fn real_main(drm: &mut DrmBackend) {
                             KeyState::Pressed => 1,
                             KeyState::Released => 0
                         };
+                        // To avoid keys staying active on switching layers.
+                        for key in &mut layers[active_layer].buttons {
+                            if key.active {
+                                key.set_active(&mut uinput, false)
+                            }
+                        }
                         if active_layer != new_layer {
                             active_layer = new_layer;
                             needs_complete_redraw = true;


### PR DESCRIPTION
# Fix bug that caused button to be perpetually held down

This should fix a bug I encountered where if you released the fn key while pressing a button, then the system would think that button held down. It's most obvious with something like toggle mute as it just keeps toggling forever.

The fix here sets the state of any active buttons on the active layer to false when it switches layers.

Built on aarch64 (fedora-asahi), seems to test fine and resolve the issue.