### PR TITLE
Switchable layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ The most basic dynamic function row daemon possible
 ## Dependencies
 cairo, libinput, freetype, fontconfig, uinput enabled in kernel config
 
+Install the following packages on Fedora:
+
+```
+dnf install -y glib2-devel cairo-devel pango-devel cairo-gobject-devel libinput-devel gdk-pixbuf2-devel systemd-devel
+```
+
 ## License
 
 tiny-dfr is licensed under the MIT license, as included in the [LICENSE](LICENSE) file.

--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -35,6 +35,10 @@ AdaptiveBrightness = true
 # Accepted values are 0-255
 ActiveBrightness = 128
 
+# Set this to true if you want to be able to switch the default layer
+# (function or media keys) by pressing the Fn key
+FnToggleLayers = false
+
 # This key defines the contents of the primary layer
 # (the one with F{number} keys)
 # You can change the individual buttons, add, or remove them

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub font_face: FontFace,
     pub adaptive_brightness: bool,
     pub active_brightness: u32,
+    pub fn_toggle_layers: bool,
 }
 
 #[derive(Deserialize)]
@@ -33,6 +34,7 @@ struct ConfigProxy {
     font_template: Option<String>,
     adaptive_brightness: Option<bool>,
     active_brightness: Option<u32>,
+    fn_toggle_layers: Option<bool>,
     primary_layer_keys: Option<Vec<ButtonConfig>>,
     media_layer_keys: Option<Vec<ButtonConfig>>
 }
@@ -74,6 +76,7 @@ fn load_config() -> (Config, [FunctionLayer; 2]) {
         base.media_layer_keys = user.media_layer_keys.or(base.media_layer_keys);
         base.primary_layer_keys = user.primary_layer_keys.or(base.primary_layer_keys);
         base.active_brightness = user.active_brightness.or(base.active_brightness);
+        base.fn_toggle_layers = user.fn_toggle_layers.or(base.fn_toggle_layers);
     };
     let media_layer = FunctionLayer::with_config(base.media_layer_keys.unwrap());
     let fkey_layer = FunctionLayer::with_config(base.primary_layer_keys.unwrap());
@@ -82,6 +85,7 @@ fn load_config() -> (Config, [FunctionLayer; 2]) {
         show_button_outlines: base.show_button_outlines.unwrap(),
         enable_pixel_shift: base.enable_pixel_shift.unwrap(),
         adaptive_brightness: base.adaptive_brightness.unwrap(),
+        fn_toggle_layers: base.fn_toggle_layers.unwrap(),
         font_face: load_font(&base.font_template.unwrap()),
         active_brightness: base.active_brightness.unwrap()
     };


### PR DESCRIPTION
Add a config knob to be able to switch which layer (function or media keys) is shown on the touchbar by default.

The default layer is only changed if no touchbar event was emitted while the Fn key was pressed.