### PR TITLE
backlight: try to find device(s) a few times before failing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
               packages.${system}.default
             ];
             packages = [
-    	        pkgs.rustfmt
+              pkgs.rustfmt
               pkgs.rust-analyzer
             ];
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";


### PR DESCRIPTION
`tiny-dfr` may run into a race condition where backlight devices might not yet be available at the time of the daemon's initialization. This PR adds logic to check for the devices for a total of 5 times with an interval of 1 second before failing. 

Tested on `MacBookPro16,2` and seems to be stable.