### PR TITLE
Add retina display backlight rules

### DIFF
--- a/etc/systemd/system/tiny-dfr.service
+++ b/etc/systemd/system/tiny-dfr.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Tiny Apple silicon touch bar daemon
-After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service systemd-logind.service
-BindsTo=dev-tiny_dfr_display.device dev-tiny_dfr_backlight.device
+After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service systemd-logind.service dev-tiny_dfr_display.device dev-tiny_dfr_backlight.device dev-tiny_dfr_display_backlight.device
+BindsTo=dev-tiny_dfr_display.device dev-tiny_dfr_backlight.device dev-tiny_dfr_display_backlight.device
 
 [Service]
 ExecStart=/usr/bin/tiny-dfr

--- a/etc/udev/rules.d/99-touchbar-tiny-dfr.rules
+++ b/etc/udev/rules.d/99-touchbar-tiny-dfr.rules
@@ -8,3 +8,8 @@ SUBSYSTEM=="drm", KERNEL=="card[0-9]*", DRIVERS=="adp|appletbdrm", TAG+="systemd
 
 SUBSYSTEM=="backlight", KERNEL=="appletb_backlight", DRIVERS=="hid-appletb-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
 SUBSYSTEM=="backlight", KERNEL=="228200000.display-pipe.0", DRIVERS=="panel-summit", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_backlight"
+
+SUBSYSTEM=="backlight", KERNEL=="apple-panel-bl", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+SUBSYSTEM=="backlight", KERNEL=="intel_backlight", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"
+SUBSYSTEM=="backlight", KERNEL=="acpi_video0", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/tiny_dfr_display_backlight"


### PR DESCRIPTION
Continuing from #43. This PR adds missing `udev` rules and the related `systemd` dependencies for the Retina display backlight devices.

Unlike #43, this method does not require trying to find devices repeatedly with an interval.

Tested on `MacBookPro16,2`.