### PR TITLE
Implement button stretch

### DIFF
--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -40,10 +40,15 @@ ActiveBrightness = 128
 # You can change the individual buttons, add, or remove them
 # Any number of keys that is greater than 0 is allowed
 # however rendering will start to break around 24 keys
+# Buttons can be made larger by setting the optional Stretch field
+# to a number greater than 1 (which means the button will take up
+# that many button spaces).
 PrimaryLayerKeys = [
     # Action defines the key code to send when the button is pressed
     # Text defines the button label
     # Icon specifies the icon to be used for the button.
+    # Stretch specifies how many button spaces the button should take up
+    # and defaults to 1
     # Icons can either be svgs or pngs, with svgs being preferred
     # For best results with pngs, they should be 48x48
     # Do not include the extension in the file name.
@@ -66,6 +71,22 @@ PrimaryLayerKeys = [
     { Text = "F10", Action = "F10" },
     { Text = "F11", Action = "F11" },
     { Text = "F12", Action = "F12" }
+    # Example with Stretch:
+    # # because most buttons have stretch 2, they behave as if they all had 1:
+    # { Text = "F1",  Action = "F1", Stretch = 2  },
+    # { Text = "F2",  Action = "F2", Stretch = 2  },
+    # # these two buttons are half the size of the other buttons:
+    # { Text = "F3",  Action = "F3", Stretch = 1  },
+    # { Text = "F4",  Action = "F4", Stretch = 1  },
+    # { Text = "F5",  Action = "F5", Stretch = 2  },
+    # { Text = "F6",  Action = "F6", Stretch = 2  },
+    # { Text = "F7",  Action = "F7", Stretch = 2  },
+    # # these two buttons are one and a half the size of the other buttons:
+    # { Text = "F8",  Action = "F8", Stretch = 3  },
+    # { Text = "F9",  Action = "F9", Stretch = 3  },
+    # { Text = "F10", Action = "F10", Stretch = 2 },
+    # { Text = "F11", Action = "F11", Stretch = 2 },
+    # { Text = "F12", Action = "F12", Stretch = 2 }
 ]
 
 # This key defines the contents of the media key layer
@@ -83,4 +104,3 @@ MediaLayerKeys = [
     { Icon = "volume_down",     Action = "VolumeDown"     },
     { Icon = "volume_up",       Action = "VolumeUp"       }
 ]
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use anyhow::Error;
 use cairo::FontFace;
-use crate::{FunctionLayer, Button};
+use crate::FunctionLayer;
 use crate::fonts::{FontConfig, Pattern};
 use freetype::Library as FtLibrary;
 use input_linux::Key;
@@ -43,7 +43,8 @@ pub struct ButtonConfig {
     #[serde(alias = "Svg")]
     pub icon: Option<String>,
     pub text: Option<String>,
-    pub action: Key
+    pub action: Key,
+    pub stretch: Option<usize>,
 }
 
 fn load_font(name: &str) -> FontFace {
@@ -75,14 +76,16 @@ fn load_config(width: u16) -> (Config, [FunctionLayer; 2]) {
         base.primary_layer_keys = user.primary_layer_keys.or(base.primary_layer_keys);
         base.active_brightness = user.active_brightness.or(base.active_brightness);
     };
-    let media_layer = FunctionLayer::with_config(base.media_layer_keys.unwrap());
-    let fkey_layer = FunctionLayer::with_config(base.primary_layer_keys.unwrap());
-    let mut layers = if base.media_layer_default.unwrap(){ [media_layer, fkey_layer] } else { [fkey_layer, media_layer] };
+    let mut media_layer_keys = base.media_layer_keys.unwrap();
+    let mut primary_layer_keys = base.primary_layer_keys.unwrap();
     if width >= 2170 {
-        for layer in &mut layers {
-            layer.buttons.insert(0, Button::new_text("esc".to_string(), Key::Esc));
+        for layer in [&mut media_layer_keys, &mut primary_layer_keys] {
+            layer.insert(0, ButtonConfig { icon: None, text: Some("esc".into()), action: Key::Esc, stretch: None });
         }
     }
+    let media_layer = FunctionLayer::with_config(media_layer_keys);
+    let fkey_layer = FunctionLayer::with_config(primary_layer_keys);
+    let layers = if base.media_layer_default.unwrap(){ [media_layer, fkey_layer] } else { [fkey_layer, media_layer] };
     let cfg = Config {
         show_button_outlines: base.show_button_outlines.unwrap(),
         enable_pixel_shift: base.enable_pixel_shift.unwrap(),


### PR DESCRIPTION
This PR implements button stretch, thus making it possible to define larger buttons.

Larger buttons can be defined by using the optional `Stretch` field:

```toml
MediaLayerKeys = [
    # ...
    { Icon = "search", Action = "Search", Stretch = 2 },
    { Icon = "play_pause", Action = "PlayPause" } # has a default stretch of 1
    # ...
]
```

The stretch value must be a positive integer and means that the button will be that many times bigger than the buttons with the default stretch value of 1.
However, fractional stretch values are possible by modifying all button stretches:

```toml
PrimaryLayerKeys = [
    { Text = "F1",  Action = "F1", Stretch = 2  }, # because most buttons have stretch 2, they behave as if they all had 1
    { Text = "F2",  Action = "F2", Stretch = 2  },
    { Text = "F3",  Action = "F3", Stretch = 1  }, # < these two buttons are half the size of the other buttons
    { Text = "F4",  Action = "F4", Stretch = 1  }, # <
    { Text = "F5",  Action = "F5", Stretch = 2  },
    { Text = "F6",  Action = "F6", Stretch = 2  },
    { Text = "F7",  Action = "F7", Stretch = 2  },
    { Text = "F8",  Action = "F8", Stretch = 3  }, # < these two buttons are one and a half the size of the other buttons
    { Text = "F9",  Action = "F9", Stretch = 3  }, # <
    { Text = "F10", Action = "F10", Stretch = 2 },
    { Text = "F11", Action = "F11", Stretch = 2 },
    { Text = "F12", Action = "F12", Stretch = 2 }
]
```

Closes #42.