### PR TITLE
Add support for freedesktop icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "cssparser"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +271,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -367,6 +423,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freedesktop-icons"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ef34245e0540c9a3ce7a28340b98d2c12b75da0d446da4e8224923fcaa0c16"
+dependencies = [
+ "dirs",
+ "once_cell",
+ "rust-ini",
+ "thiserror",
+ "xdg",
 ]
 
 [[package]]
@@ -733,6 +802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "librsvg"
 version = "2.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,9 +1109,25 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
 
 [[package]]
 name = "pango"
@@ -1369,6 +1464,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1616,12 +1732,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "tiny-dfr"
 version = "0.3.2"
 dependencies = [
  "anyhow",
  "cairo-rs",
  "drm",
+ "freedesktop-icons",
  "freetype-rs",
  "input",
  "input-linux",
@@ -1634,6 +1771,15 @@ dependencies = [
  "rand",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1950,6 +2096,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xml5ever"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 rand = "0.8"
 freetype-rs = "0.37"
+freedesktop-icons = "0.2.6"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703068421,
-        "narHash": "sha256-WSw5Faqlw75McIflnl5v7qVD/B3S2sLh+968bpOGrWA=",
+        "lastModified": 1729449015,
+        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d65bceaee0fb1e64363f7871bc43dc1c6ecad99f",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "The most basic dynamic function row daemon possible";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
   };
   outputs = { self, nixpkgs }:
     let

--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -47,12 +47,14 @@ PrimaryLayerKeys = [
     # Action defines the key code to send when the button is pressed
     # Text defines the button label
     # Icon specifies the icon to be used for the button.
+    # Theme specifies the XDG icons theme.
     # Stretch specifies how many button spaces the button should take up
     # and defaults to 1
     # Icons can either be svgs or pngs, with svgs being preferred
     # For best results with pngs, they should be 48x48
     # Do not include the extension in the file name.
-    # Icons are looked up in /etc/tiny-dfr first and then in /usr/share/tiny-dfr
+    # If a Theme is set, icons are looked up in XDG_DATA_DIRS.
+    # Otherwise, they are first looked up in /etc/tiny-dfr, and then in /usr/share/tiny-dfr.
     # Only one of Text or Icon is allowed,
     # if both are present, the behavior is undefined.
     # For the list of supported key codes see
@@ -71,6 +73,7 @@ PrimaryLayerKeys = [
     { Text = "F10", Action = "F10" },
     { Text = "F11", Action = "F11" },
     { Text = "F12", Action = "F12" }
+
     # Example with Stretch:
     # # because most buttons have stretch 2, they behave as if they all had 1:
     # { Text = "F1",  Action = "F1", Stretch = 2  },
@@ -103,4 +106,18 @@ MediaLayerKeys = [
     { Icon = "volume_off",      Action = "Mute"           },
     { Icon = "volume_down",     Action = "VolumeDown"     },
     { Icon = "volume_up",       Action = "VolumeUp"       }
+
+    # Example with XDG icons (requires `breeze-dark` theme installed):
+    # { Icon = "brightness-low",        Theme = "breeze-dark", Action = "BrightnessDown" },
+    # { Icon = "brightness-high",       Theme = "breeze-dark", Action = "BrightnessUp"   },
+    # { Icon = "microphone",            Theme = "breeze-dark", Action = "MicMute"        },
+    # { Icon = "search",                Theme = "breeze-dark", Action = "Search"         },
+    # { Icon = "redshift-status-day",   Theme = "breeze-dark", Action = "IllumDown"      },
+    # { Icon = "redshift-status-night", Theme = "breeze-dark", Action = "IllumUp"        },
+    # { Icon = "media-skip-backward",   Theme = "breeze-dark", Action = "PreviousSong"   },
+    # { Icon = "media-playback-start",  Theme = "breeze-dark", Action = "PlayPause"      },
+    # { Icon = "media-skip-forward",    Theme = "breeze-dark", Action = "NextSong"       },
+    # { Icon = "audio-volume-muted",    Theme = "breeze-dark", Action = "Mute"           },
+    # { Icon = "audio-volume-low",      Theme = "breeze-dark", Action = "VolumeDown"     },
+    # { Icon = "audio-volume-high",     Theme = "breeze-dark", Action = "VolumeUp"       }
 ]

--- a/share/tiny-dfr/config.toml
+++ b/share/tiny-dfr/config.toml
@@ -108,16 +108,16 @@ MediaLayerKeys = [
     { Icon = "volume_up",       Action = "VolumeUp"       }
 
     # Example with XDG icons (requires `breeze-dark` theme installed):
-    # { Icon = "brightness-low",        Theme = "breeze-dark", Action = "BrightnessDown" },
-    # { Icon = "brightness-high",       Theme = "breeze-dark", Action = "BrightnessUp"   },
-    # { Icon = "microphone",            Theme = "breeze-dark", Action = "MicMute"        },
-    # { Icon = "search",                Theme = "breeze-dark", Action = "Search"         },
-    # { Icon = "redshift-status-day",   Theme = "breeze-dark", Action = "IllumDown"      },
-    # { Icon = "redshift-status-night", Theme = "breeze-dark", Action = "IllumUp"        },
-    # { Icon = "media-skip-backward",   Theme = "breeze-dark", Action = "PreviousSong"   },
-    # { Icon = "media-playback-start",  Theme = "breeze-dark", Action = "PlayPause"      },
-    # { Icon = "media-skip-forward",    Theme = "breeze-dark", Action = "NextSong"       },
-    # { Icon = "audio-volume-muted",    Theme = "breeze-dark", Action = "Mute"           },
-    # { Icon = "audio-volume-low",      Theme = "breeze-dark", Action = "VolumeDown"     },
-    # { Icon = "audio-volume-high",     Theme = "breeze-dark", Action = "VolumeUp"       }
+    # { Icon = "brightness-low",       Theme = "breeze-dark", Action = "BrightnessDown" },
+    # { Icon = "brightness-high",      Theme = "breeze-dark", Action = "BrightnessUp"   },
+    # { Icon = "microphone",           Theme = "breeze-dark", Action = "MicMute"        },
+    # { Icon = "search",               Theme = "breeze-dark", Action = "Search"         },
+    # { Icon = "redshift-status-day",  Theme = "breeze-dark", Action = "IllumDown"      },
+    # { Icon = "redshift-status-on",   Theme = "breeze-dark", Action = "IllumUp"        },
+    # { Icon = "media-skip-backward",  Theme = "breeze-dark", Action = "PreviousSong"   },
+    # { Icon = "media-playback-start", Theme = "breeze-dark", Action = "PlayPause"      },
+    # { Icon = "media-skip-forward",   Theme = "breeze-dark", Action = "NextSong"       },
+    # { Icon = "audio-volume-muted",   Theme = "breeze-dark", Action = "Mute"           },
+    # { Icon = "audio-volume-low",     Theme = "breeze-dark", Action = "VolumeDown"     },
+    # { Icon = "audio-volume-high",    Theme = "breeze-dark", Action = "VolumeUp"       }
 ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,7 @@ pub struct ButtonConfig {
     #[serde(alias = "Svg")]
     pub icon: Option<String>,
     pub text: Option<String>,
+    pub theme: Option<String>,
     pub action: Key,
     pub stretch: Option<usize>,
 }
@@ -80,7 +81,7 @@ fn load_config(width: u16) -> (Config, [FunctionLayer; 2]) {
     let mut primary_layer_keys = base.primary_layer_keys.unwrap();
     if width >= 2170 {
         for layer in [&mut media_layer_keys, &mut primary_layer_keys] {
-            layer.insert(0, ButtonConfig { icon: None, text: Some("esc".into()), action: Key::Esc, stretch: None });
+            layer.insert(0, ButtonConfig { icon: None, text: Some("esc".into()), theme: None, action: Key::Esc, stretch: None });
         }
     }
     let media_layer = FunctionLayer::with_config(media_layer_keys);

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,9 @@ fn try_load_image(name: impl AsRef<str>, theme: Option<impl AsRef<str>>) -> Resu
         // Freedesktop icons
         let theme = theme.as_ref();
         let candidates = vec![
-            lookup(name).with_cache().with_theme(theme).force_svg().find(),
+            lookup(name).with_cache().with_theme(theme).with_size(ICON_SIZE as u16).force_svg().find(),
             lookup(name).with_cache().with_theme(theme).with_size(ICON_SIZE as u16).find(),
+            lookup(name).with_cache().with_theme(theme).force_svg().find(),
             lookup(name).with_cache().with_theme(theme).find(),
         ];
 


### PR DESCRIPTION
This PR adds support for Freedesktop / XDG icons, using the `freedesktop_icons` library. In the configuration, it's now possible to use icons from a theme installed in the system, like so:

```
MediaLayerKeys = [
    # ... other keys ...
    { Icon = "firefox",            Theme = "hicolor",     Action = "F23" },
    { Icon = "dialog-information", Theme = "breeze-dark", Action = "F24" },
    # ... other keys ...
]
```

The `Theme` parameter is optional, and if it's omitted, the icon lookup will proceed like before, searching in `/etc/tiny-dfr` and then `/usr/share/tiny-dfr`. Lookup of themes is based on the `XDG_DATA_DIRS` environment variable.

The code around loading icons was also refactored a bit, adding better error messages when loading fails. Nix flake was also updated (it wouldn't let me compile with the current year-old flake).